### PR TITLE
Fixes for Compilation on Modern Systems

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,12 +1,12 @@
 # Change the following to match your environment.
 # Specifically, you may have to add -Lpath or -Ipath to FLAGS to point to correct paths of boost/blas/lapack libraries.
 CXX=g++
-CXXFLAGS=-std=c++14 -DNDEBUG -O3 -march=native -Wall -c -I/opt/homebrew/include -I/opt/homebrew/opt/openblas/include -I/opt/homebrew/opt/gcc/include
+CXXFLAGS=-DNDEBUG -O3 -march=native -Wall -c
 CC=gcc
 CFLAGS=-O0 -Wall -c
-FC=gfortran
+FC=gcc
 FCFLAGS=-m64 -c
-LDFLAGS=-L/opt/homebrew/opt/gcc/lib/gcc/13 -L/opt/homebrew/opt/openblas/lib -lopenblas -lpthread -lgfortran
+LDFLAGS=-lblas -llapack -lpthread -lgfortran -lrt
 
 
 CXXSOURCES=src/data.cpp src/data_model.cpp src/main.cpp src/matrix.cpp src/model.cpp src/prior.cpp src/sampler.cpp src/symmmatrix.cpp src/utils.cpp src/vector.cpp src/inih/cpp/INIReader.cpp

--- a/makefile
+++ b/makefile
@@ -1,12 +1,12 @@
 # Change the following to match your environment.
 # Specifically, you may have to add -Lpath or -Ipath to FLAGS to point to correct paths of boost/blas/lapack libraries.
 CXX=g++
-CXXFLAGS=-DNDEBUG -O3 -march=native -Wall -c
+CXXFLAGS=-std=c++14 -DNDEBUG -O3 -march=native -Wall -c -I/opt/homebrew/include -I/opt/homebrew/opt/openblas/include -I/opt/homebrew/opt/gcc/include
 CC=gcc
 CFLAGS=-O0 -Wall -c
-FC=gcc
+FC=gfortran
 FCFLAGS=-m64 -c
-LDFLAGS=-lblas -llapack -lpthread -lgfortran -lrt
+LDFLAGS=-L/opt/homebrew/opt/gcc/lib/gcc/13 -L/opt/homebrew/opt/openblas/lib -lopenblas -lpthread -lgfortran
 
 
 CXXSOURCES=src/data.cpp src/data_model.cpp src/main.cpp src/matrix.cpp src/model.cpp src/prior.cpp src/sampler.cpp src/symmmatrix.cpp src/utils.cpp src/vector.cpp src/inih/cpp/INIReader.cpp

--- a/src/data.hpp
+++ b/src/data.hpp
@@ -4,17 +4,17 @@
  *
  * http://becs.aalto.fi/en/research/bayes/bmagwa/
  * Copyright 2012 Tomi Peltola <tomi.peltola@aalto.fi>
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -25,6 +25,7 @@
 
 #include <cmath>
 #include <map>
+#include <string>
 #include "linalg.hpp"
 
 namespace bmagwa {

--- a/src/sampler.hpp
+++ b/src/sampler.hpp
@@ -4,17 +4,17 @@
  *
  * http://becs.aalto.fi/en/research/bayes/bmagwa/
  * Copyright 2012 Tomi Peltola <tomi.peltola@aalto.fi>
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -652,7 +652,7 @@ class Sampler
       double* cumulative_model_probabilities = new double[movesize + 1];
 
       log_model_probabilities[0] = 0;
-      int Ns_old[4] = {smallest_model_size, 0.0, 0.0, 0.0};
+	  int Ns_old[4] = {static_cast<int>(smallest_model_size), 0, 0, 0};
       for (unsigned char i = 1; i <= movesize; ++i){
         // cumulative change from smallest to largest
         log_model_probabilities[i] = log_model_probabilities[i-1]

--- a/src/vector.hpp
+++ b/src/vector.hpp
@@ -4,17 +4,17 @@
  *
  * http://becs.aalto.fi/en/research/bayes/bmagwa/
  * Copyright 2012 Tomi Peltola <tomi.peltola@aalto.fi>
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -29,6 +29,7 @@
 #include <cmath>
 #include <cblas.h>
 #include <cstring>
+#include <algorithm>
 
 namespace bmagwa {
 


### PR DESCRIPTION
First: thank you for creating `bmagwa`! I've found it to be very useful for GWAS, particularly on smaller data sets.

Secondly: when attempting to compile `bmagwa` on a new system (macbook with M1 Max chip), a number of errors occurred. Some errors had to do with my specific build-environment and were resolved by installing relevant libraries and tweaking the makefile. Other errors seemed to have to do with idiosyncrasies of newer C++ compiler versions. This pull request addresses those compiler-related issues. The modifications are minimal and should be backwards compatible with older compilers.

Specifically I added the following `#include` statements:

- `#include <string>` in `data.hpp`
- `#include <algorithm>` in `vector.hpp`

In `sampler.hpp`, I changed the initialisation of `Ns_old[4]` to avoid problems with "narrowing conversions": `NS_old` is an integer array, but is initialised with non-integer values (0.0 instead of 0), and types (the variable `smallest_model_size` is of type `size_t` - an unsigned long type). I changed the doubles to ints, and cast the variable to integer in that initialisation (it could be declared directly as int elsewhere I suppose).

Thanks again, and le me know if you need more info or if there are any changes you'd like me to make on this pull request.

Kind regards,
Anders