### PR TITLE
rewrite to be compatible with python3

### DIFF
--- a/bmagwa_postprocess.py
+++ b/bmagwa_postprocess.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Postprocessing utilities for BMAGWA software (v2.0)
 # Author: Tomi Peltola <tomi.peltola@aalto.fi>
@@ -20,10 +20,10 @@ def writeok(filename):
   doit = True
   if os.path.exists(filename):
     doit = False
-    print 'File already exists: %s' % filename
-    a = raw_input('Overwrite [y/n]? ')
+    print('File already exists: %s' % filename)
+    a = input('Overwrite [y/n]? ')
     while a not in ['y', 'n']:
-      a = raw_input('Overwrite [y/n]? ')
+      a = input('Overwrite [y/n]? ')
     if a == 'y':
       doit = True
   return doit
@@ -36,7 +36,7 @@ def convert(args):
   else:
     fmt = guess_fmt(args[0])
   if fmt == None:
-    print >> sys.stderr, 'Cannot guess format for %s. Skipping.' % filename
+    print('Cannot guess format for %s. Skipping.' % filename, file=sys.stderr)
     return
   if writeok(outfile):
     f = open(outfile, 'w')
@@ -51,10 +51,10 @@ def output(args):
   else:
     fmt = guess_fmt(args[0])
   if fmt == None:
-    print >> sys.stderr, 'Cannot guess format for %s. Skipping.' % filename
+    print('Cannot guess format for %s. Skipping.' % filename, file=sys.stderr)
     return
   for x in read_data(filename, fmt):
-    print x
+    print(x)
 
 def guess_fmt(filename):
   import re
@@ -85,15 +85,14 @@ def mcmcpos(args):
     thin = max(1, int(args[3]))
   else:
     thin = 1
-  
+
   directory, name = os.path.split(basename)
   if directory == '': directory = '.'
-  filenames = filter(lambda x: re.match(name + r'\d+_loci.dat$', x) != None,
-                     os.listdir(directory))
-  print "mcmcpos: Using following chains to compute association probabilities:"
-  for x in filenames: print " " + x
+  filenames = [x for x in os.listdir(directory) if re.match(name + r'\d+_loci.dat$', x) != None]
+  print("mcmcpos: Using following chains to compute association probabilities:")
+  for x in filenames: print(" " + x)
   p = [[0.0] * nsnps for x in filenames]
-  
+
   for i,f in enumerate(filenames):
     msfile = f.replace('_loci.', '_modelsize.')
     loci = read_data(os.path.join(directory, f), guess_fmt(f))
@@ -101,14 +100,14 @@ def mcmcpos(args):
     for j,ms in enumerate(read_data(os.path.join(directory, msfile),
                           guess_fmt(msfile))):
       if j < burnin or (j - burnin) % thin != 0:
-        for x in range(int(ms)): loci.next()
+        for x in range(int(ms)): next(loci)
       else:
         nsamples += 1
         for x in range(int(ms)):
-          p[i][int(loci.next())] += 1.0
+          p[i][int(next(loci))] += 1.0
     for j,val in enumerate(p[i]):
       p[i][j] = val / nsamples
-  
+
     outfile = os.path.join(directory, f.replace('_loci.dat', '_mcmcpos.txt'))
     if writeok(outfile):
       fout = open(outfile, 'w')
@@ -119,7 +118,7 @@ def mcmcpos(args):
   outfile = os.path.join(directory, name + '_mcmcpos.txt')
   if writeok(outfile):
     fout = open(outfile, 'w')
-    for i in xrange(nsnps):
+    for i in range(nsnps):
       fout.write(str(sum((x[i] for x in p)) / len(p)) + '\n')
     fout.close()
 
@@ -131,7 +130,7 @@ if __name__ == "__main__":
     sys.exit()
   if nargs >= 3 and sys.argv[1] != "mcmcpos" and \
      not os.path.exists(sys.argv[2]):
-    print >> sys.stderr, "File or directory does not exist: %s" % sys.argv[2]
+    print("File or directory does not exist: %s" % sys.argv[2], file=sys.stderr)
     sys.exit()
   if nargs == 3 and sys.argv[1] == "convert" and os.path.isdir(sys.argv[2]):
     for x in (f for f in os.listdir(sys.argv[2]) if f.endswith('.dat')):
@@ -141,35 +140,35 @@ if __name__ == "__main__":
   elif nargs >= 3 and sys.argv[1] == "output":
     output(sys.argv[2:])
   else:
-    print "Usage: python %s options" % sys.argv[0]
-    print "where options is one of following:"
-    print "(nothing or invalid) : print help"
-    print "convert directory    : converts all binary files (.dat) to text"
-    print "                       files."
-    print "convert filename     : converts binary file with name filename to"
-    print "                       text file."
-    print "convert filename fmt : converts binary file with name filename and"
-    print "                       format fmt to text file."
-    print "output filename      : similar to convert but prints to standard"
-    print "                       output."
-    print "output filename fmt  : similar to convert but prints to standard"
-    print "                       output."
-    print "mcmcpos bn nsnps b t : computes posterior association probabilities"
-    print "                       from MCMC chains with basename bn (i.e., path"
-    print "                       to loci.dat files up to just before the chain"
-    print "                       number). nsnps is the number of SNPs in the"
-    print "                       dataset, b is the number of burnin samples to"
-    print "                       drop and t is thinning (in addition to the"
-    print "                       one specified in the configuration file)."
-    print
-    print "Convert commands write output to 'filename' + '.txt'."
-    print "Mcmcpos writes to files 'basenameX_mcmcpos.txt' and"
-    print "'basename_mcmcpos.txt' (combined posterior of all chains)."
-    print
-    print "Examples:"
-    print "python %s convert results" % sys.argv[0]
-    print "python %s convert results/chain1_modelsize.dat" % sys.argv[0]
-    print "python %s convert results/chain1_modelsize.dat I" % sys.argv[0]
-    print "python %s output results/chain0_rao.dat > rao0.txt" % sys.argv[0]
-    print "python %s mcmcpos results/chain 10000 50000 1" % sys.argv[0]
+    print("Usage: python %s options" % sys.argv[0])
+    print("where options is one of following:")
+    print("(nothing or invalid) : print help")
+    print("convert directory    : converts all binary files (.dat) to text")
+    print("                       files.")
+    print("convert filename     : converts binary file with name filename to")
+    print("                       text file.")
+    print("convert filename fmt : converts binary file with name filename and")
+    print("                       format fmt to text file.")
+    print("output filename      : similar to convert but prints to standard")
+    print("                       output.")
+    print("output filename fmt  : similar to convert but prints to standard")
+    print("                       output.")
+    print("mcmcpos bn nsnps b t : computes posterior association probabilities")
+    print("                       from MCMC chains with basename bn (i.e., path")
+    print("                       to loci.dat files up to just before the chain")
+    print("                       number). nsnps is the number of SNPs in the")
+    print("                       dataset, b is the number of burnin samples to")
+    print("                       drop and t is thinning (in addition to the")
+    print("                       one specified in the configuration file).")
+    print()
+    print("Convert commands write output to 'filename' + '.txt'.")
+    print("Mcmcpos writes to files 'basenameX_mcmcpos.txt' and")
+    print("'basename_mcmcpos.txt' (combined posterior of all chains).")
+    print()
+    print("Examples:")
+    print("python %s convert results" % sys.argv[0])
+    print("python %s convert results/chain1_modelsize.dat" % sys.argv[0])
+    print("python %s convert results/chain1_modelsize.dat I" % sys.argv[0])
+    print("python %s output results/chain0_rao.dat > rao0.txt" % sys.argv[0])
+    print("python %s mcmcpos results/chain 10000 50000 1" % sys.argv[0])
 


### PR DESCRIPTION
I updated the bmagwa_postprocess.py script from python2 to python3 (by running 2to3 on it...). I guess most people would use python3 now and it makes sense to replace the python2 version, but let me know if I should change the pull request so that there are separate versions for 2 and 3.

The changes include print statements changed to functions, xrange changed to range, raw_input changed to input, and generator.next() changed to next(generator).

I tested the updated script on one example output, and that worked.

Best regards,
Anders